### PR TITLE
Exposición de menú y transferencia de acciones a `loop()`

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -231,7 +231,7 @@ void handleNotFound() {
   handleRoot();
 }
 
-void initWifiConnection(String ssid, String password) {
+void initWifiConnection(char* ssid, char* password) {
     // Conectar a red externa como cliente
     Serial.print("Conectando a WiFi: ");
     SerialBT.print("Conectando a WiFi: ");


### PR DESCRIPTION
Ahora el menú se muestra antes de que se introduzca un comando, y muchas funciones (conectarse a WiFi, inicializar AP, manejar requests DNS) están dentro de `loop()`. **Falta que el usuario pueda introducir el SSID y contraseña directamente en Terminal de Bluetooth.**